### PR TITLE
Additional flexibility around session keys

### DIFF
--- a/Kerberos.NET/Client/ApplicationSessionContext.cs
+++ b/Kerberos.NET/Client/ApplicationSessionContext.cs
@@ -15,15 +15,19 @@ namespace Kerberos.NET.Client
 
         public KrbEncryptionKey SessionKey { get; set; }
 
+        public KrbEncryptionKey ClientSubSessionKey { get; set; }
+
+        public KrbEncryptionKey ServerSubSessionKey { get; set; }
+
         public int? SequenceNumber { get; set; }
 
         public int CuSec { get; set; }
 
         public DateTimeOffset CTime { get; set; }
 
-        public KrbEncryptionKey AuthenticateServiceResponse(string asRepEncoded)
+        public KrbEncryptionKey AuthenticateServiceResponse(string apRepEncoded)
         {
-            return AuthenticateServiceResponse(Convert.FromBase64String(asRepEncoded));
+            return AuthenticateServiceResponse(Convert.FromBase64String(apRepEncoded));
         }
 
         public KrbEncryptionKey AuthenticateServiceResponse(ReadOnlyMemory<byte> apRepBytes)
@@ -37,11 +41,35 @@ namespace Kerberos.NET.Client
                 SequenceNumber = this.SequenceNumber
             };
 
-            decrypted.Decrypt(this.SessionKey.AsKey());
+            DecryptApRep(decrypted);
 
             decrypted.Validate(ValidationActions.TokenWindow);
+            ServerSubSessionKey = decrypted.Response.SubSessionKey;
 
-            return decrypted.Response.SubSessionKey ?? this.SessionKey;
+            return ServerSubSessionKey ?? this.SessionKey;
         }
+
+        private void DecryptApRep(DecryptedKrbApRep decrypted)
+        {
+            foreach(var key in new[] {
+                this.SessionKey,
+                this.ClientSubSessionKey
+            })
+            {
+                if (key == null) continue;
+                try
+                {
+                    decrypted.Decrypt(key.AsKey());
+                    return;
+                }
+                catch (Exception)
+                {
+                    // Not this key, continue to the next one
+                }
+            }
+
+            throw new InvalidOperationException("Failed to decrypt AP_REP with any of the provided keys.");
+        }
+
     }
 }

--- a/Kerberos.NET/Client/KerberosClient.cs
+++ b/Kerberos.NET/Client/KerberosClient.cs
@@ -882,7 +882,8 @@ namespace Kerberos.NET.Client
                         rst,
                         out KrbAuthenticator authenticator
                     ),
-                    SessionKey = authenticator.Subkey ?? serviceTicketCacheEntry.SessionKey,
+                    SessionKey = serviceTicketCacheEntry.SessionKey,
+                    ClientSubSessionKey = authenticator.Subkey,
                     CTime = authenticator.CTime,
                     CuSec = authenticator.CuSec,
                     SequenceNumber = authenticator.SequenceNumber

--- a/Kerberos.NET/Crypto/DecryptedKrbApRep.cs
+++ b/Kerberos.NET/Crypto/DecryptedKrbApRep.cs
@@ -61,14 +61,6 @@ namespace Kerberos.NET.Crypto
                     nameof(this.CuSec)
                 );
             }
-
-            if (this.SequenceNumber != this.Response.SequenceNumber)
-            {
-                throw new KerberosValidationException(
-                    $"SequenceNumber does not match. Sent: {this.SequenceNumber}; Received: {this.Response.SequenceNumber}",
-                    nameof(this.SequenceNumber)
-                );
-            }
         }
     }
 }


### PR DESCRIPTION

### What's the problem?

The code was using the "wrong" key to decrypt the AP_REP. WinRM is using the session key instead of the session subkey and there was no way to make Kerberos.NET use the session key.

There was also an issue with the validation of the seqence number since WinRM returns a different sequence number. In the spec there doesn't seem to be any requirement for the sequence numbers to match.

- [x ] Bugfix


### What's the solution?

Allow the session key or the client session subkey to be used and also exposes the server subkey in the ApplicationSessionContext.

### What issue is this related to, if any?

https://github.com/dotnet/Kerberos.NET/issues/398
